### PR TITLE
feat: Add customHeaders option

### DIFF
--- a/Sources/GOFeatureFlag/controller/goff_api.swift
+++ b/Sources/GOFeatureFlag/controller/goff_api.swift
@@ -44,6 +44,11 @@ class GoFeatureFlagAPI {
             "application/json",
             forHTTPHeaderField: "Content-Type"
         )
+        if let headers = self.options.customHeaders {
+            for (key, value) in headers {
+                request.SetValue(value, forHTTPHeaderField: key)
+            }
+        }
         if let apiKey = self.options.apiKey {
             request.setValue("Bearer \(apiKey)", forHTTPHeaderField:"Authorization")
         }

--- a/Sources/GOFeatureFlag/options.swift
+++ b/Sources/GOFeatureFlag/options.swift
@@ -21,6 +21,11 @@ public struct GoFeatureFlagProviderOptions {
      */
     public var apiKey: String?
     /**
+     * (optional) custom headers to be sent for every HTTP request.
+     * default: empty
+     */
+    public var customHeaders: [String:String]? = [:]
+    /**
      * (optional) interval time we publish statistics collection data to the proxy.
      * The parameter is used only if the cache is enabled, otherwise the collection of the data is done directly
      * when calling the evaluation API.
@@ -42,12 +47,14 @@ public struct GoFeatureFlagProviderOptions {
         endpoint: String,
         pollInterval: TimeInterval = 60,
         apiKey: String? = nil,
+        customHeaders: [String:String]? = [:],
         dataFlushInterval: TimeInterval = 600,
         exporterMetadata: [String:ExporterMetadataValue]? = [:],
         networkService: NetworkingService? = URLSession.shared) {
         self.endpoint = endpoint
         self.pollInterval = pollInterval
         self.apiKey = apiKey
+        self.customHeaders = customHeaders
         self.networkService = networkService
         self.dataCollectorInterval = dataFlushInterval
         self.exporterMetadata = exporterMetadata

--- a/Sources/GOFeatureFlag/provider.swift
+++ b/Sources/GOFeatureFlag/provider.swift
@@ -20,7 +20,7 @@ public final class GoFeatureFlagProvider: FeatureProvider {
             networkService = netSer
         }
 
-        var headers: [String:String] = [:]
+        var headers: [String:String] = options.customHeaders ?? [:]
         if let apiKey = options.apiKey {
             headers["Authorization"] = "Bearer \(apiKey)"
         }

--- a/Tests/GOFeatureFlagTests/goff_api_tests.swift
+++ b/Tests/GOFeatureFlagTests/goff_api_tests.swift
@@ -203,4 +203,29 @@ class GoffApiTests: XCTestCase {
             XCTFail("Expected GoFeatureFlagError.noEventToSend but got a different error: \(error).")
         }
     }
+
+    func testShouldSendCustomHeaders() async throws{
+        let mockService = MockNetworkingService(mockStatus: 200)
+        let options = GeFeatureFlagProviderOptions(
+            endpoint: "http://localhost:1031/",
+            customHeaders: ["X-Custom-Headers": "custom-value"]
+        )
+        let goffAPI = GoFeatureFlagAPI(networkingService: mockService, options: options)
+
+        let events: [FeatureEvent] = [
+            FeatureEvent(kind: "feature", userKey: "981f2662-1fb4-4732-ac6d-8399d9205aa9", creationDate: Int64(Date().timeIntervalSince1970),
+                         key: "flag-1", variation: "enabled", value: JSONValue.bool(true), default: false, version: nil, source: "PROVIDER_CACHE")
+        ]
+
+        do {
+            _ = try await goffAPI.postDataCollector(events: events)
+            guard let request = mockService.requests.last else {
+                XCTFail("No request captured")
+                return
+            }
+            XCTAssertEqual("custom-value", request.allHTTPHeaderFields?["X-Custom-Header"])
+        } catch {
+            XCTFail("exception thrown when doing the evaluation: \(error)")
+        }
+    }
 }

--- a/Tests/GOFeatureFlagTests/provider_tests.swift
+++ b/Tests/GOFeatureFlagTests/provider_tests.swift
@@ -204,4 +204,33 @@ class GoFeatureFlagProviderTests: XCTestCase {
         XCTAssertEqual(2, mockNetworkService.dataCollectorCallCounter)
         XCTAssertEqual(6, mockNetworkService.dataCollectorEventCounter)
     }
+
+    func testProviderCustomHeaders() async {
+        let mockNetworkService = MockNetworkingService(mockStatus: 200)
+        let provider = GoFeatureFlagProvider(
+            options: GoFeatureFlagProviderOptions(
+                endpoint: "https://localhost:1031",
+                apiKey: "apiKey1"
+                customHeaders: [
+                    "X-Custom-Header": "custom-value",
+                    "Authorization": "Bearer custom" // should be overwritten by apiKey
+                ]
+                networkService: mockNetworkService
+            )
+        )
+        let evaluationCtx = MutableContext(targetingKey: "ede04e44-463d-40d1-8fc0-b1d6855578d0")
+        let api = OpenFeatureAPI()
+        await api.setProviderAndWait(provider: provider, initialContext: evaluationCtx)
+        let client = api.getClient()
+
+        _ = client.getBooleanDetails(key: "my-flag", defaultValue: false)
+
+        guard let request = mockNetworkService.requests.last else {
+            XCTFail("No request captured")
+            return
+        }
+
+        XCTAssertEqual("custom-value", request.allHTTPHeaderFields?["X-Custom-Header"])
+        XCTAssertEqual("Bearer apiKey1", request.allHTTPHeaderFields?["Authorization"])
+    }
 }


### PR DESCRIPTION
# Description

Adds support for custom headers for every HTTP request, similar to the [option found on the Ruby SDK](https://github.com/open-feature/ruby-sdk-contrib/blob/413cfd8f65e62dc14bd514001e32f1b140dcdf3e/providers/openfeature-go-feature-flag-provider/lib/openfeature/go-feature-flag/options.rb#L16). Custom headers can be used to define a `User-Agent`, to prevent requests from being blocked by servers that require browser-like identification or specific device signatures.

## Notes
Our WAF requires the `User-Agent` header to be defined. Requests to the relay-proxy are being denied because the header is not specified.

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
